### PR TITLE
Add example extending form validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { createApp } from 'vue'
-import App from './examples/composition-functional/tic-tac-toe-app.vue'
+import App from './examples/form-validation/form-validation.vue'
 
 const app = createApp(App)
 app.mount('#app')

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "axios": "^0.21.0",
     "luxon": "^1.25.0",
     "moment": "^2.29.1",
     "vite": "^1.0.0-rc.4",
@@ -7,11 +8,11 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.11.5",
-    "ts-node": "^9.0.0",
     "@vue/compiler-sfc": "^3.0.0",
     "@vue/test-utils": "^2.0.0-beta.4",
     "babel-jest": "^26.3.0",
     "jest": "25.0.0",
+    "ts-node": "^9.0.0",
     "typescript": "^4.0.2",
     "vue-jest": "^5.0.0-alpha.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,6 +1653,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-jest@^25.5.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.5.1.tgz#bc2e6101f849d6f6aec09720ffc7bc5332e62853"
@@ -2773,7 +2780,7 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==


### PR DESCRIPTION
Try it out. Clone the repo, `yarn install` and `yarn vite`. Visit `localhost:3000`. Submit the form.

Main changes:

- add a `serverValidation` reactive object that mirrors the patient form's validation API (`{ valid: false, message: '...' }`).
- add a `submitted` flag. This decides if we have submitted the form - good for disabling the form during submission to prevent submitting the form multiple times, and also to use the `serverValidation` instead of the `clientValidation`.